### PR TITLE
chore: refactor to aid test coverage and development

### DIFF
--- a/configurations/hcloudci_config.yaml
+++ b/configurations/hcloudci_config.yaml
@@ -5,3 +5,4 @@
 configName: hcloudci
 grpcMandated: true
 deferredAssert: true
+beforeEachCheckAndRestart: true

--- a/configurations/selfci_config.yaml
+++ b/configurations/selfci_config.yaml
@@ -4,6 +4,7 @@
 configName: selfci
 grpcMandated: true
 selfTest: true
+beforeEachCheckAndRestart: true
 pvcStress:
   replicas: 1
   cdCycles: 1
@@ -58,7 +59,7 @@ multiVolumesPodIO:
   volumeSizeMb: 64
 maximumVolsIO:
   # 4 volumes
-  volMb: 1024
+  volMb: 64
   volumeCountPerPod: 2
   podCount: 2
   duration: 30s

--- a/src/common/custom_resources/util.go
+++ b/src/common/custom_resources/util.go
@@ -119,20 +119,13 @@ func CheckAllMsPoolsAreOnline() error {
 	return err
 }
 
-func MakeAccumulatedError(accErr error, err error) error {
-	if accErr == nil {
-		return err
-	}
-	return fmt.Errorf("%v; %v", accErr, err)
-}
-
 // CheckAllMsPoolFinalizers check
 //	1) that finalizers exist for pools with replicas (used size != 0)
 //  2) that finalizers DO NOT EXIST for pools with no replicas (used size == 0)
 // Note this function should not be call if mayastor is deployed with control plane
 // versions > 0
 func CheckAllMsPoolFinalizers() error {
-	var accErr error
+	var errs common.ErrorAccumulator
 	pools, err := ListMsPools()
 	if err != nil {
 		return err
@@ -141,11 +134,11 @@ func CheckAllMsPoolFinalizers() error {
 	for _, pool := range pools {
 		finalizer := pool.Finalizers
 		if finalizer != nil {
-			accErr = MakeAccumulatedError(accErr, fmt.Errorf("finalizer set on pool: %s", pool.Name))
+			errs.Add(fmt.Errorf("finalizer set on pool: %s", pool.Name))
 		}
 	}
 
-	return accErr
+	return errs.GetError()
 }
 
 // == Mayastor Nodes ======================

--- a/src/common/custom_resources/util.go
+++ b/src/common/custom_resources/util.go
@@ -134,7 +134,7 @@ func CheckAllMsPoolFinalizers() error {
 	for _, pool := range pools {
 		finalizer := pool.Finalizers
 		if finalizer != nil {
-			errs.Add(fmt.Errorf("finalizer set on pool: %s", pool.Name))
+			errs.Accumulate(fmt.Errorf("finalizer set on pool: %s", pool.Name))
 		}
 	}
 

--- a/src/common/e2e_config/e2e_config.go
+++ b/src/common/e2e_config/e2e_config.go
@@ -57,21 +57,25 @@ type E2EConfig struct {
 	E2eFioImage string `yaml:"e2eFioImage" env-default:"mayadata/e2e-fio" env:"e2e_fio_image"`
 	E2eFsxImage string `yaml:"e2eFsxImage" env-default:"mayadata/e2e-fsx" env:"e2e_fsx_image"`
 	// This is an advisory setting for individual tests
-	// If set to true - typically during test development - tests with multiple It clauses should defer asserts till after
-	// resources have been cleaned up . This behaviour makes it possible to have useful runs for all It clauses.
-	// Typically set to false for CI test execution - no cleanup after first failure, as a result subsequent It clauses
+	// If set to true - typically during test development - tests with multiple 'It' clauses should defer asserts till after
+	// resources have been cleaned up . This behaviour makes it possible to have useful runs for all 'It' clauses.
+	// Typically, set to false for CI test execution - no cleanup after first failure, as a result subsequent 'It' clauses
 	// in the test will fail the BeforeEach check, rendering post-mortem checks on the cluster more useful.
 	// It may be set to true for when we want maximum test coverage, and post-mortem analysis is a secondary requirement.
 	// NOTE: Only some tests support this feature.
 	DeferredAssert bool `yaml:"deferredAssert" env-default:"false" env:"e2e_defer_asserts"`
 	// TODO: for now using a simple boolean for a specific behaviour suffices, a more sophisticated approach using a policy for test runs may be required.
-	CleanupOnBeforeEach bool `yaml:"cleanupOnBeforeEach" env-default:"false" env:"e2e_policy_cleanup_before"`
+
 	// Default replica count, used by tests which do not have a config section.
 	DefaultReplicaCount int `yaml:"defaultReplicaCount" env-default:"2" env:"e2e_default_replica_count"`
 	// Timeout for MOAC CR state reconciliation in seconds, some CR state is not update promptly for example pool usage
 	// and finalizers. On hcloud the time lag between synchronisation has been observed to be in the order of
 	// a minute.
 	MoacSyncTimeoutSeconds int `yaml:"moacSyncTimeoutSeconds" env-default:"600"`
+	// Restart Mayastor on failure in a prior AfterEach or ResourceCheck
+	BeforeEachCheckAndRestart bool `yaml:"beforeEachCheckAndRestart" env-default:"false"`
+	// Fail  quickly after failure of a prior AfterEach, overrides BeforeEachCheckAndRestart
+	FailQuick bool `yaml:"failQuick" env-default:"false" env:"e2e_fail_quick"`
 
 	// Run configuration
 	ReportsDir string `yaml:"reportsDir" env:"e2e_reports_dir"`

--- a/src/common/k8stest/test.go
+++ b/src/common/k8stest/test.go
@@ -204,27 +204,22 @@ func resourceCheck(waitForPools bool) error {
 	var errs = common.ErrorAccumulator{}
 
 	pods, err := CheckForTestPods()
-	if err != nil {
-		errs.Add(err)
-	}
+	errs.Accumulate(err)
 	if pods {
-		errs.Add(fmt.Errorf("found Pods"))
+		errs.Accumulate(fmt.Errorf("found Pods"))
 	}
 
 	pvcs, err := CheckForPVCs()
-	if err != nil {
-		errs.Add(err)
-	}
+	errs.Accumulate(err)
 	if pvcs {
-		errs.Add(fmt.Errorf("found PersistentVolumeClaims"))
+		errs.Accumulate(fmt.Errorf("found PersistentVolumeClaims"))
 	}
 
 	pvs, err := CheckForPVs()
-	if err != nil {
-		errs.Add(err)
-	}
+	errs.Accumulate(err)
+
 	if pvs {
-		errs.Add(fmt.Errorf("found PersistentVolumes"))
+		errs.Accumulate(fmt.Errorf("found PersistentVolumes"))
 	}
 
 	//FIXME: control plane 1 temporary do not check MSVs
@@ -232,11 +227,11 @@ func resourceCheck(waitForPools bool) error {
 		// Mayastor volumes
 		msvs, err := ListMsvs()
 		if err != nil {
-			errs.Add(err)
+			errs.Accumulate(err)
 		} else {
 			if msvs != nil {
 				if len(msvs) != 0 {
-					errs.Add(fmt.Errorf("found MayastorVolumes"))
+					errs.Accumulate(fmt.Errorf("found MayastorVolumes"))
 				}
 			} else {
 				logf.Log.Info("Listing MSVs returned nil array")
@@ -250,21 +245,19 @@ func resourceCheck(waitForPools bool) error {
 		if e2e_config.GetConfig().SelfTest {
 			logf.Log.Info("SelfTesting, ignoring:", "", err)
 		} else {
-			errs.Add(err)
+			errs.Accumulate(err)
 		}
 	}
 
 	scs, err := CheckForStorageClasses()
-	if err != nil {
-		errs.Add(err)
-	}
+	errs.Accumulate(err)
 	if scs {
-		errs.Add(fmt.Errorf("found storage classes using mayastor"))
+		errs.Accumulate(fmt.Errorf("found storage classes using mayastor"))
 	}
 
 	err = custom_resources.CheckAllMsPoolsAreOnline()
 	if err != nil {
-		errs.Add(err)
+		errs.Accumulate(err)
 		logf.Log.Info("ResourceCheck: not all pools are online")
 	}
 
@@ -285,12 +278,10 @@ func resourceCheck(waitForPools bool) error {
 				}
 			}
 			logf.Log.Info("ResourceCheck:", "mspool Usage", mspUsage, "waiting time", time.Since(t0))
-			if err != nil {
-				errs.Add(err)
-			}
+			errs.Accumulate(err)
 		}
 		if mspUsage != 0 {
-			errs.Add(fmt.Errorf("pool usage reported via custom resources %d", mspUsage))
+			errs.Accumulate(fmt.Errorf("pool usage reported via custom resources %d", mspUsage))
 		}
 		logf.Log.Info("ResourceCheck:", "mspool Usage", mspUsage)
 	}
@@ -316,11 +307,9 @@ func resourceCheck(waitForPools bool) error {
 				}
 				logf.Log.Info("ResourceCheck:", "poolUsage", poolUsage, "waiting time", time.Since(t0))
 			}
-			if err != nil {
-				errs.Add(err)
-			}
+			errs.Accumulate(err)
 			if poolUsage != 0 {
-				errs.Add(fmt.Errorf("gRPC: pool usage reported via custom resources %d", poolUsage))
+				errs.Accumulate(fmt.Errorf("gRPC: pool usage reported via custom resources %d", poolUsage))
 			}
 			logf.Log.Info("ResourceCheck:", "poolUsage", poolUsage)
 		}
@@ -328,36 +317,36 @@ func resourceCheck(waitForPools bool) error {
 		{
 			nexuses, err := ListNexusesInCluster()
 			if err != nil {
-				errs.Add(err)
+				errs.Accumulate(err)
 				logf.Log.Info("ResourceEachCheck: failed to retrieve list of nexuses")
 			}
 			logf.Log.Info("ResourceCheck:", "num nexuses", len(nexuses))
 			if len(nexuses) != 0 {
-				errs.Add(fmt.Errorf("gRPC: count of nexuses reported via mayastor client is %d", len(nexuses)))
+				errs.Accumulate(fmt.Errorf("gRPC: count of nexuses reported via mayastor client is %d", len(nexuses)))
 			}
 		}
 		// check replicas
 		{
 			replicas, err := ListReplicasInCluster()
 			if err != nil {
-				errs.Add(err)
+				errs.Accumulate(err)
 				logf.Log.Info("ResourceEachCheck: failed to retrieve list of replicas")
 			}
 			logf.Log.Info("ResourceCheck:", "num replicas", len(replicas))
 			if len(replicas) != 0 {
-				errs.Add(fmt.Errorf("gRPC: count of replicas reported via mayastor client is %d", len(replicas)))
+				errs.Accumulate(fmt.Errorf("gRPC: count of replicas reported via mayastor client is %d", len(replicas)))
 			}
 		}
 		// check nvmeControllers
 		{
 			nvmeControllers, err := ListNvmeControllersInCluster()
 			if err != nil {
-				errs.Add(err)
+				errs.Accumulate(err)
 				logf.Log.Info("ResourceEachCheck: failed to retrieve list of nvme controllers")
 			}
 			logf.Log.Info("ResourceCheck:", "num nvme controllers", len(nvmeControllers))
 			if len(nvmeControllers) != 0 {
-				errs.Add(fmt.Errorf("gRPC: count of replicas reported via mayastor client is %d", len(nvmeControllers)))
+				errs.Accumulate(fmt.Errorf("gRPC: count of replicas reported via mayastor client is %d", len(nvmeControllers)))
 			}
 		}
 	} else {

--- a/src/common/k8stest/util.go
+++ b/src/common/k8stest/util.go
@@ -678,13 +678,6 @@ func WorkaroundForMQ1536() {
 	Expect(err).ToNot(HaveOccurred(), "failed to delete all pool finalizers (WorkaroundForMQ1536)")
 }
 
-func MakeAccumulatedError(accErr error, err error) error {
-	if accErr == nil {
-		return err
-	}
-	return fmt.Errorf("%v; %v", accErr, err)
-}
-
 // DeleteVolumeAttachmets deletes volume attachments for a node
 func DeleteVolumeAttachments(nodeName string) error {
 	volumeAttachments, err := gTestEnv.KubeInt.StorageV1().VolumeAttachments().List(context.TODO(), metaV1.ListOptions{})
@@ -718,11 +711,13 @@ func CheckAndSetControlPlane() error {
 	if err = gTestEnv.K8sClient.Get(context.TODO(), types.NamespacedName{Name: "moac", Namespace: common.NSMayastor()}, &deployment); err == nil {
 		foundMoac = true
 	}
+
 	// Check for core-agents either as deployment or statefulset to correctly handle older builds of control plane
 	// which use core-agents deployment and newer builds which use core-agents statefulset
 	if err = gTestEnv.K8sClient.Get(context.TODO(), types.NamespacedName{Name: "core-agents", Namespace: common.NSMayastor()}, &deployment); err == nil {
 		foundCoreAgents = true
 	}
+
 	if err = gTestEnv.K8sClient.Get(context.TODO(), types.NamespacedName{Name: "core-agents", Namespace: common.NSMayastor()}, &statefulSet); err == nil {
 		foundCoreAgents = true
 	}

--- a/src/common/k8stest/util_cleanup.go
+++ b/src/common/k8stest/util_cleanup.go
@@ -293,9 +293,7 @@ func DeleteAllPoolFinalizers() (bool, error) {
 
 	for _, pool := range pools {
 		deleted, err := deletePoolFinalizer(pool.GetName())
-		if err != nil {
-			errs.Add(err)
-		}
+		errs.Accumulate(err)
 		deletedFinalizer = deletedFinalizer || deleted
 	}
 

--- a/src/common/k8stest/util_cleanup.go
+++ b/src/common/k8stest/util_cleanup.go
@@ -283,7 +283,7 @@ func deletePoolFinalizer(poolName string) (bool, error) {
 
 func DeleteAllPoolFinalizers() (bool, error) {
 	deletedFinalizer := false
-	var deleteErr error
+	var errs common.ErrorAccumulator
 
 	pools, err := custom_resources.ListMsPools()
 	if err != nil {
@@ -294,12 +294,12 @@ func DeleteAllPoolFinalizers() (bool, error) {
 	for _, pool := range pools {
 		deleted, err := deletePoolFinalizer(pool.GetName())
 		if err != nil {
-			deleteErr = MakeAccumulatedError(deleteErr, err)
+			errs.Add(err)
 		}
 		deletedFinalizer = deletedFinalizer || deleted
 	}
 
-	return deletedFinalizer, deleteErr
+	return deletedFinalizer, errs.GetError()
 }
 
 func DeleteAllPools() bool {

--- a/src/common/types.go
+++ b/src/common/types.go
@@ -1,5 +1,7 @@
 package common
 
+import "fmt"
+
 type ShareProto string
 
 const (
@@ -136,4 +138,24 @@ type MayastorPoolStatus struct {
 type MayastorPoolInterface interface {
 	GetMsPool(poolName string) (*MayastorPool, error)
 	ListMsPools() ([]MayastorPool, error)
+}
+
+type ErrorAccumulator struct {
+	errs []error
+}
+
+func (acc *ErrorAccumulator) Add(err error) {
+	acc.errs = append(acc.errs, err)
+}
+
+func (acc *ErrorAccumulator) GetError() error {
+	var err error
+	for _, e := range acc.errs {
+		if err != nil {
+			err = fmt.Errorf("%w; %v", err, e)
+		} else {
+			err = e
+		}
+	}
+	return err
 }

--- a/src/common/types.go
+++ b/src/common/types.go
@@ -144,8 +144,10 @@ type ErrorAccumulator struct {
 	errs []error
 }
 
-func (acc *ErrorAccumulator) Add(err error) {
-	acc.errs = append(acc.errs, err)
+func (acc *ErrorAccumulator) Accumulate(err error) {
+	if err != nil {
+		acc.errs = append(acc.errs, err)
+	}
 }
 
 func (acc *ErrorAccumulator) GetError() error {


### PR DESCRIPTION
Add a configuration item "beforeEachCheckAndRestart" to enable
 restarts in the BeforeEachCheck function.
Currently if an 'It' clause of test fails and leaves
resources, the cluster is considered unusable because
of indeterminate state.
Setting beforeEachCheckRestart changes the behaviour such
that mayastor is restarted if
    - If prior ResourceCheck has failed
    - ResourceCheck fails
The 2nd behaviour may help for selfci runs.

Add a configuration item "failQuick" to ease debugging and
development of tests.
When trying to determine reasons for failure, developers
prefer fast fail.
fail quick doesn't quite manage that, it only affects the i
behaviour of the generic BeforeEachCheck and AfterEachCheck functions.
ResourceCheck errors are stored persistently and if fail quick
is enabled both functions return immediately.

Finally change so that on BeforeEachChecks we do not wait
for pool state to reach the desired 0 value
    - the timeouts are large
    - timeouts will have been exercised in the prior
        AfterEachCheck

Refactor to simplify functions which accumulate errors
