### PR TITLE
chore: fix pod running or complete check

### DIFF
--- a/src/MQ-1783-fsx_ext4_stress/config.go
+++ b/src/MQ-1783-fsx_ext4_stress/config.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	podCompletionTimeout = 900
-	sleepTime            = 2
+	sleepTime            = 10
 	defTimeoutSecs       = "90s"
 	patchSleepTime       = 10
 	patchTimeout         = 240

--- a/src/MQ-1783-fsx_ext4_stress/fsx_ext4_stress_test.go
+++ b/src/MQ-1783-fsx_ext4_stress/fsx_ext4_stress_test.go
@@ -51,7 +51,7 @@ func (c *fsxExt4StressConfig) fsxExt4StressTest() {
 	c.createPVC()
 	c.createFsx()
 	c.verifyVolumeStateOverGrpcAndCrd()
-	c.verifyUninterruptedIO()
+	c.verifyRunning()
 	c.getNexusDetail()
 	c.faultNexusChild()
 	c.verifyFaultedReplica()

--- a/src/MQ-1783-fsx_ext4_stress/util.go
+++ b/src/MQ-1783-fsx_ext4_stress/util.go
@@ -191,21 +191,15 @@ func (c *fsxExt4StressConfig) verifyUninterruptedIO() {
 	logf.Log.Info("Verify status", "pod", c.fsxPodName)
 	var fsxPodPhase coreV1.PodPhase
 	var err error
-	var status bool
-	Eventually(func() bool {
-		status = k8stest.IsPodRunning(c.fsxPodName, common.NSDefault)
-		return status
-	},
-		defTimeoutSecs,
-		"1s",
-	).Should(Equal(true))
+	status := k8stest.IsPodRunning(c.fsxPodName, common.NSDefault)
+	logf.Log.Info("Verify status", "pod", c.fsxPodName, "IsPodRunning", status)
 	if !status {
 		// check pod phase
 		fsxPodPhase, err = k8stest.CheckPodContainerCompleted(c.fsxPodName, common.NSDefault)
 		Expect(err).ToNot(HaveOccurred(), "Failed to get %s pod phase ", c.fsxPodName)
 	}
 	if fsxPodPhase == coreV1.PodSucceeded {
-		logf.Log.Info("pod", "name", c.fsxPodName, "phase", fsxPodPhase)
+		logf.Log.Info("Verify status", "pod", c.fsxPodName, "phase", fsxPodPhase)
 	} else {
 		Expect(status).To(Equal(true), "fsx pod %s phase is %v", c.fsxPodName, fsxPodPhase)
 	}

--- a/src/MQ-1783-fsx_ext4_stress/util.go
+++ b/src/MQ-1783-fsx_ext4_stress/util.go
@@ -186,6 +186,18 @@ func (c *fsxExt4StressConfig) verifyVolumeStateOverGrpcAndCrd() {
 
 }
 
+// verify IO is in progress
+func (c *fsxExt4StressConfig) verifyRunning() {
+	var fsxPodPhase coreV1.PodPhase
+	logf.Log.Info("Verify running", "pod", c.fsxPodName)
+	status := k8stest.IsPodRunning(c.fsxPodName, common.NSDefault)
+	logf.Log.Info("Verify running", "pod", c.fsxPodName, "IsPodRunning", status)
+	if !status {
+		fsxPodPhase, _ = k8stest.CheckPodContainerCompleted(c.fsxPodName, common.NSDefault)
+	}
+	Expect(status).To(Equal(true), "fsx pod %s phase is %v", c.fsxPodName, fsxPodPhase)
+}
+
 // verify status of IO after fault injection
 func (c *fsxExt4StressConfig) verifyUninterruptedIO() {
 	logf.Log.Info("Verify status", "pod", c.fsxPodName)


### PR DESCRIPTION
When verifying pod state sample pod running state,
and act accordingly.

Tweak sleep times to generate fewer repeated messages.