### PR TITLE
fix: k8stest.CheckPodComplete: null pointer check

### DIFF
--- a/src/common/k8stest/util_testpods.go
+++ b/src/common/k8stest/util_testpods.go
@@ -339,7 +339,8 @@ func CheckPodContainerCompleted(podName string, nameSpace string) (coreV1.PodPha
 	for _, containerStatus := range containerStatuses {
 		if containerStatus.Name == podName {
 			if !containerStatus.Ready {
-				if containerStatus.State.Terminated.Reason == "Completed" {
+				if containerStatus.State.Terminated != nil &&
+					containerStatus.State.Terminated.Reason == "Completed" {
 					if containerStatus.State.Terminated.ExitCode == 0 {
 						return coreV1.PodSucceeded, nil
 					} else {


### PR DESCRIPTION
In CheckPodContainerCompleted avoid null pointer access
of field pod.Status.ContainerStatuses[n].State.Terminated

This also means that CheckPodComplete can be invoked,
without checking for prior transition to running state.