### PR TITLE
fix(fault_injection_test):  timeout to wait for replicas to be in degraded or online state

### DIFF
--- a/src/primitive_fault_injection/config.go
+++ b/src/primitive_fault_injection/config.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	sleepTime      = 2
-	defTimeoutSecs = "120s"
+	defTimeoutSecs = "600s"
 	patchSleepTime = 10
 	patchTimeout   = 240
 )


### PR DESCRIPTION
Some times faulted replica takes time to recreate itself on same pool, so to avoid test failure due to this below changes are done:

- Add eventually loop to wait for faulted replica to removed and check for replicas state as degraded and online state.
- Increase default time out value to 240 seconds