### PR TITLE
fix(RestartMayastorPods): verify restart with the mayastor pod count before tests begin

### DIFF
--- a/src/common/k8stest/test.go
+++ b/src/common/k8stest/test.go
@@ -400,7 +400,15 @@ func BeforeEachCheck() error {
 	if resourceCheckError = resourceCheck(false); resourceCheckError != nil {
 		logf.Log.Info("BeforeEachCheck failed", "error", resourceCheckError)
 		resourceCheckError = fmt.Errorf("%w; not running test case, k8s cluster is not \"clean\"!!! ", resourceCheckError)
+	} else {
+		podNames, err := listMayastorPods(nil)
+		if err != nil {
+			err = fmt.Errorf("%w; not running test case, not able to get pod list", err)
+			return err
+		}
+		SetMayastorInitialPodCount(len(podNames))
 	}
+
 	return resourceCheckError
 }
 

--- a/src/common/k8stest/util_testpods.go
+++ b/src/common/k8stest/util_testpods.go
@@ -353,6 +353,16 @@ func CheckPodContainerCompleted(podName string, nameSpace string) (coreV1.PodPha
 	return pod.Status.Phase, err
 }
 
+var mayastorInitialPodCount int
+
+func SetMayastorInitialPodCount(count int) {
+	mayastorInitialPodCount = count
+}
+
+func GetMayastorInitialPodCount() int {
+	return mayastorInitialPodCount
+}
+
 // List mayastor pod names, conditionally
 //  1) No timestamp - all mayastor pods
 //	2) With timestamp - all mayastor pods created after the timestamp which are Running.
@@ -429,7 +439,7 @@ func RestartMayastorPods(timeoutSecs int) error {
 		newPodNames, err = listMayastorPods(&now)
 		if err == nil {
 			logf.Log.Info("Restarted", "pods", newPodNames)
-			if len(newPodNames) >= len(podNames) {
+			if len(newPodNames) >= GetMayastorInitialPodCount() {
 				logf.Log.Info("All pods have been restarted.")
 				return nil
 			}


### PR DESCRIPTION
RestartMayastorPods() func is useful in removing the restart count on the mayastor pods once the disruptive test has been completed. This is done to prepare stage for the next test.

Previously we were taking the restart count just at the beginning of the restart function. This was sometimes giving wrong numbers as the test might leave the cluster in any state. At some instances there were 2 pods in the list for the same deployment, one in running and the other in terminating/pending/....

In this PR, we are taking the mayastor pod count for comparision purposes just at the beginning of the test. 

Signed-off-by: Payes Anand <payes.anand@mayadata.io>