### PR TITLE
fix: tweak nexus_location test

### DIFF
--- a/src/nexus_location/nexus_location_test.go
+++ b/src/nexus_location/nexus_location_test.go
@@ -169,6 +169,9 @@ func remotelyProvisionedVolume(replicas int, local bool) {
 		logf.Log.Info("Failed to list nexuses")
 	}
 
+	logf.Log.Info("sleep... 60 secs")
+	time.Sleep(60 * time.Second)
+
 	// Delete the fio pod
 	err = k8stest.DeletePod(fioPodName, ns)
 	Expect(err).ToNot(HaveOccurred(), "failed to delete test pod")


### PR DESCRIPTION
After checking whether a pod is provisioned,
sleep for 1 minute and then delete the pod,
this stops the test failing on k8s 1.22 and k8s 1.23.

Ostensibly the test fails because pvc deletion does not
complete successfully, however the root cause is that
the pod using the pvc is not deleted.

Adding the delay lets k8s complete the deletion of the pod,
and naturally pvc deletion will then complete.