### PR TITLE
fix: Remove dependency of common functions on ginkgo e2e-test config

### DIFF
--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Usage: cd src/<testname> &&
+#
+USAGE="Usage: $0 <path_to_test_dir> [path_to_kubectl_mayastor]"
+
+if [ -z "$KUBECONFIG" ]; then
+    echo "KUBECONFIG not defined, tests are unable to access the test cluster"
+    exit 1
+fi
+
+if [ "$1" == "-h" ] || [ -z "$1" ]; then
+    echo "$USAGE"
+    exit 1
+fi
+
+cd "$1" || exit 1
+shift
+
+if [ -z "$1" ]; then
+    if ! tmp=$(which kubectl-mayastor); then
+        :
+    fi
+    if [ -z "$tmp" ]; then
+        echo "$USAGE"
+        exit 1
+    else
+        echo "NOTE: Found and using $tmp"
+        kcm="$tmp"
+    fi
+else
+    kcm="$1"
+fi
+
+if [ -f "$kcm" ]; then
+    echo "Checking $kcm get volumes"
+    "$kcm" get volumes
+else
+    echo "$kcm is not a file"
+    echo "$USAGE"
+    exit 1
+fi
+
+kcdir=$(dirname "$kcm")
+export e2e_kubectl_plugin_dir="${kcdir}"
+# fail quick => if first It clause failed attempt to skip
+# subsequent It clauses - works if on failure,
+# resources created in It clause are left "dangling"
+export e2e_fail_quick="true"
+go test -v . -ginkgo.v -ginkgo.progress -timeout 0

--- a/src/common/e2e_config/e2e_config.go
+++ b/src/common/e2e_config/e2e_config.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"runtime"
 	"strings"
 	"sync"
 
@@ -290,9 +289,9 @@ func GetConfig() E2EConfig {
 		if !haveE2ERootDir {
 			// try to work out the root directory of the mayastor-e2e repo so
 			// that configuration file loading will work
-			_, filename, _, ok := runtime.Caller(0)
-			if ok {
-				comps := strings.Split(filename, "/")
+			cwd, err := os.Getwd()
+			if err == nil {
+				comps := strings.Split(cwd, "/")
 				for ix, comp := range comps {
 					// Expect mayastor-e2e/src/...
 					if comp == "mayastor-e2e" && len(comps[ix:]) > 2 && comps[ix+1] == "src" {


### PR DESCRIPTION
Add scripts/runtest.sh this
 - allows us to test the fix
 - simplifies running tests manually