### PR TITLE
test(e2e): e2e-agent client status code check

### DIFF
--- a/src/common/e2e-agent/client.go
+++ b/src/common/e2e-agent/client.go
@@ -54,6 +54,9 @@ func sendRequestGetResponse(reqType, url string, data interface{}, verbose bool)
 		return "", err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("request returned code %d", resp.StatusCode)
+	}
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
e2e-agent client code was not checking the http
response code after making the rest call.
Return an error if the code is anything other than 200.