### PR TITLE
test(e2e): e2e-agent kill mayastor functionality

### DIFF
--- a/src/common/e2e-agent/client.go
+++ b/src/common/e2e-agent/client.go
@@ -150,3 +150,10 @@ func ControlDevice(serverAddr string, device string, state string) (string, erro
 	}
 	return sendRequestGetResponse("POST", url, data, false)
 }
+
+// KillMayastor use kill -9 against the mayastor
+func KillMayastor(serverAddr string) (string, error) {
+	logf.Log.Info("Killing Mayastor", "addr", serverAddr)
+	url := "http://" + serverAddr + ":" + RestPort + "/killmayastor"
+	return sendRequestGetResponse("POST", url, nil, true)
+}


### PR DESCRIPTION
Extend e2e-agent to permit the killing of the mayastor process on a node 