### PR TITLE
test(etfw): specify image tags

### DIFF
--- a/src/tools/extended-test-framework/log_monitor/scripts/build.sh
+++ b/src/tools/extended-test-framework/log_monitor/scripts/build.sh
@@ -1,12 +1,46 @@
 #!/usr/bin/env bash
 
-set -e pipefail
+set -euo pipefail
 
 SCRIPT_DIR=$(dirname "$0")
+TAG="latest"
+
+help() {
+  cat <<EOF
+Usage: $0 [OPTIONS]
+
+Options:
+  --tag <name> 		tag to assign to built images
+Examples:
+  $0 --tag my_custom_tag
+EOF
+}
+
+# Parse arguments
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -t|--tag)
+      shift
+      echo "building with tag $1"
+      TAG="$1"
+      ;;
+    -h)
+      help
+      exit 0
+      ;;
+    *)
+      echo "unrecognized parameter"
+      help
+      exit 1
+      ;;
+  esac
+  shift
+done
+
 pushd ${SCRIPT_DIR}
 
 pushd ../cmd/main && CGO_ENABLED=0 go build -a -installsuffix cgo -o log_monitor && popd
 
-./build_img.sh
+./build_img.sh ${TAG}
 
 popd

--- a/src/tools/extended-test-framework/log_monitor/scripts/build_img.sh
+++ b/src/tools/extended-test-framework/log_monitor/scripts/build_img.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 
-set -e pipefail
+set -euo pipefail
 
 REGISTRY="ci-registry.mayastor-ci.mayadata.io"
 TAG="latest"
 APP="log_monitor"
 IMG_NAME=mayadata/${APP}
 SCRIPT_DIR=$(dirname "$0")
+
+if (($# == 1)); then
+        TAG=$1
+fi
+
 pushd ${SCRIPT_DIR}
 
 pushd ../docker

--- a/src/tools/extended-test-framework/scripts/build.sh
+++ b/src/tools/extended-test-framework/scripts/build.sh
@@ -1,13 +1,48 @@
 #!/usr/bin/env bash
 
-set -e pipefail
+set -euo pipefail
 
 SCRIPT_DIR=$(dirname "$0")
+TAG="latest"
+
+help() {
+  cat <<EOF
+Usage: $0 [OPTIONS]
+
+Options:
+  --tag <name> 		tag to assign to built images
+Examples:
+  $0 --tag my_custom_tag
+EOF
+}
+
+# Parse arguments
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -t|--tag)
+      shift
+      echo "building with tag $1"
+      TAG="$1"
+      ;;
+    -h)
+      help
+      exit 0
+      ;;
+    *)
+      echo "unrecognized parameter"
+      help
+      exit 1
+      ;;
+  esac
+  shift
+done
+
 pushd ${SCRIPT_DIR}
 
-pushd ../log_monitor/scripts && ./build.sh; popd
-pushd ../test_conductor/scripts && ./build.sh; popd
-pushd ../test_director/scripts && ./build.sh;  popd
-pushd ../workload_monitor/scripts && ./build.sh; popd
+pushd ../log_monitor/scripts && ./build.sh -t ${TAG}; popd
+pushd ../test_conductor/scripts && ./build.sh -t ${TAG}; popd
+pushd ../test_director/scripts && ./build.sh -t ${TAG}; popd
+pushd ../workload_monitor/scripts && ./build.sh -t ${TAG}; popd
 
 popd
+

--- a/src/tools/extended-test-framework/test_conductor/scripts/build.sh
+++ b/src/tools/extended-test-framework/test_conductor/scripts/build.sh
@@ -1,12 +1,44 @@
 #!/usr/bin/env bash
 
-set -e pipefail
+set -euo pipefail
 
-ETFWTAG="latest"
+TAG="latest"
+
+help() {
+  cat <<EOF
+Usage: $0 [OPTIONS]
+
+Options:
+  --tag <name> 		tag to assign to built images
+Examples:
+  $0 --tag my_custom_tag
+EOF
+}
+
+# Parse arguments
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -t|--tag)
+      shift
+      echo "building with tag $1"
+      TAG="$1"
+      ;;
+    -h)
+      help
+      exit 0
+      ;;
+    *)
+      echo "unrecognized parameter"
+      help
+      exit 1
+      ;;
+  esac
+  shift
+done
+
 
 build_img () {
 	APP=$1
-	TAG=$2
 	REGISTRY="ci-registry.mayastor-ci.mayadata.io"
 
 	mkdir -p ../docker
@@ -14,8 +46,8 @@ build_img () {
 	cp ../cmd/${APP}/${APP} .
 	cp ../cmd/${APP}/Dockerfile .
 
-	docker build -t ${REGISTRY}/mayadata/${APP}:${ETFWTAG} .
-	docker push ${REGISTRY}/mayadata/${APP}:${ETFWTAG}
+	docker build -t ${REGISTRY}/mayadata/${APP}:${TAG} .
+	docker push ${REGISTRY}/mayadata/${APP}:${TAG}
 
 	rm -Rf *
 	popd
@@ -27,7 +59,7 @@ build () {
 
 	pushd ../cmd/$1 && CGO_ENABLED=0 go build -a -installsuffix cgo && popd
 
-	build_img $1 $2
+	build_img $1
 }
 
 SCRIPT_DIR=$(dirname "$0")

--- a/src/tools/extended-test-framework/test_director/scripts/build.sh
+++ b/src/tools/extended-test-framework/test_director/scripts/build.sh
@@ -1,13 +1,45 @@
 #!/usr/bin/env bash
 
-set -e pipefail
+set -euo pipefail
 
 SCRIPT_DIR=$(dirname "$0")
 pushd ${SCRIPT_DIR}
 
+help() {
+  cat <<EOF
+Usage: $0 [OPTIONS]
+
+Options:
+  --tag <name> 		tag to assign to built images
+Examples:
+  $0 --tag my_custom_tag
+EOF
+}
+
+# Parse arguments
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -t|--tag)
+      shift
+      echo "building with tag $1"
+      TAG="$1"
+      ;;
+    -h)
+      help
+      exit 0
+      ;;
+    *)
+      echo "unrecognized parameter"
+      help
+      exit 1
+      ;;
+  esac
+  shift
+done
+
 pushd ../cmd/test-framework-server && CGO_ENABLED=0 go build -a -installsuffix cgo -o test_director && popd
 
-./build_img.sh
+./build_img.sh ${TAG}
 
 popd
 

--- a/src/tools/extended-test-framework/test_director/scripts/build_img.sh
+++ b/src/tools/extended-test-framework/test_director/scripts/build_img.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 
-set -e pipefail
+set -euo pipefail
 
 REGISTRY="ci-registry.mayastor-ci.mayadata.io"
 TAG="latest"
 APP="test_director"
 IMG_NAME=mayadata/${APP}
 SCRIPT_DIR=$(dirname "$0")
+
+if (($# == 1)); then
+        TAG=$1
+fi
+
 pushd ${SCRIPT_DIR}
 
 pushd ../docker

--- a/src/tools/extended-test-framework/workload_monitor/scripts/build.sh
+++ b/src/tools/extended-test-framework/workload_monitor/scripts/build.sh
@@ -1,14 +1,48 @@
 #!/usr/bin/env bash
 
-set -e pipefail
+set -euo pipefail
 
 SCRIPT_DIR=$(dirname "$0")
 cd ${SCRIPT_DIR}
+
+TAG="latest"
+
+help() {
+  cat <<EOF
+Usage: $0 [OPTIONS]
+
+Options:
+  --tag <name> 		tag to assign to built images
+Examples:
+  $0 --tag my_custom_tag
+EOF
+}
+
+# Parse arguments
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -t|--tag)
+      shift
+      echo "building with tag $1"
+      TAG="$1"
+      ;;
+    -h)
+      help
+      exit 0
+      ;;
+    *)
+      echo "unrecognized parameter"
+      help
+      exit 1
+      ;;
+  esac
+  shift
+done
 
 #./gen_server_code.sh
 #./gen_client_code.sh
 
 pushd ../cmd/workload_monitor && CGO_ENABLED=0 go build -a -installsuffix cgo; popd
 
-./build_img.sh
+./build_img.sh ${TAG}
 

--- a/src/tools/extended-test-framework/workload_monitor/scripts/build_img.sh
+++ b/src/tools/extended-test-framework/workload_monitor/scripts/build_img.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 
-set -eux pipefail
+set -euo pipefail
 
 REGISTRY="ci-registry.mayastor-ci.mayadata.io"
 TAG="latest"
 APP="workload_monitor"
+
+if (( $# == 1 )); then
+        TAG=$1
+fi
 
 SCRIPT_DIR=$(dirname "$0")
 cd ${SCRIPT_DIR}


### PR DESCRIPTION
Allow the docker image tag to be parameterised in the build scripts.
This makes it easier to develop new tests without impacting the
working images which typically use "latest".
TODO, update the deployment script to be parameterised as well. 