### PR TITLE
test(etfw): add XRay test to config for pool test

### DIFF
--- a/src/tools/extended-test-framework/deploy/test_conductor/primitive_pool_deletion/config.yaml
+++ b/src/tools/extended-test-framework/deploy/test_conductor/primitive_pool_deletion/config.yaml
@@ -1,5 +1,5 @@
 testName: "primitive_pool_deletion"
-test: "MQ-EXP"
+test: "MQ-2813"
 e2eFioImage: ci-registry.mayastor-ci.mayadata.io/mayadata/e2e-fio
 msnodes: 3
 duration: 14d

--- a/src/tools/extended-test-framework/test_conductor/tests/primitive_pool_deletion.go
+++ b/src/tools/extended-test-framework/test_conductor/tests/primitive_pool_deletion.go
@@ -30,21 +30,10 @@ func PrimitivePoolDeletionTest(testConductor *tc.TestConductor) error {
 		return fmt.Errorf("failed to inform test director of test start, error: %v", err)
 	}
 
-	if err = tc.AddCommonWorkloads(
-		testConductor.WorkloadMonitorClient,
-		violations); err != nil {
-		return fmt.Errorf("failed add common workloads, error: %v", err)
-	}
-
 	for ix := 0; ix < testConductor.Config.PrimitivePoolDeletion.Iterations; ix++ {
 		if err = primitivePoolDeletion(testConductor); err != nil {
 			return err
 		}
-	}
-
-	if err = tc.DeleteWorkloads(testConductor.WorkloadMonitorClient); err != nil {
-		logf.Log.Info("failed to delete all registered workloads", "error", err)
-		combinederr = fmt.Errorf("%v: failed to delete all registered workloads, error: %v", combinederr, err)
 	}
 
 	return combinederr


### PR DESCRIPTION
Add the XRay test for the primitive_pool_deletion test
to the config.
Also do not configure the workload_monitor to monitor
mayastor pods because these are forced to restart by the test,
otherwise the test will always fail.