### PR TITLE
test(etfw): replica test via killing mayastor pods

### DIFF
--- a/src/tools/extended-test-framework/deploy/test_conductor/replica_elimination/config.yaml
+++ b/src/tools/extended-test-framework/deploy/test_conductor/replica_elimination/config.yaml
@@ -7,8 +7,10 @@ sendEvent: 1
 sendXrayTest: 1
 replicaElimination:
   replicas: 3
-  volumeSizeMb: 512
+  volumeSizeMb: 128
   fsvolume: 0
   localvolume: 0
-  blocksToWrite: 50000
+  killmayastor: 1
+  blocksToWrite: 20000
+  randomSleep: 0
 

--- a/src/tools/extended-test-framework/test_conductor/tc/config.go
+++ b/src/tools/extended-test-framework/test_conductor/tc/config.go
@@ -21,6 +21,8 @@ type ReplicaElimination struct {
 	Timeout       string `yaml:"timeout" env-default:"15m"`
 	VolumeSizeMb  int    `yaml:"volumeSizeMb" env-default:"512"`
 	BlocksToWrite int    `yaml:"blocksToWrite" env-default:"100000"`
+	KillMayastor  int    `yaml:"killmayastor" env-default:"0"`
+	RandomSleep   int    `yaml:"randomSleep" env-default:"0"`
 }
 
 type ReplicaPerturbation struct {


### PR DESCRIPTION
Extend the replica elimination test to test for replicas
by killing the mayastor processes on all nodes.
A volume with no replicas, or with all replicas faulted
 is no longer considered a test failure.
Add option to run e2e-storage-tester for a given duration.
Allow test-conductor to exclude pods from workload-monitor
checking via app label.
Reduce volume sizes to speed up test.