### PR TITLE
refactor: handle images for mayastor and bolt

### DIFF
--- a/pipelines/Mayastor-e2e-selfci-image-builder/Jenkinsfile
+++ b/pipelines/Mayastor-e2e-selfci-image-builder/Jenkinsfile
@@ -100,7 +100,7 @@ pipeline {
       agent { label 'nixos-mayastor' }
       steps {
         // on success re-tag images as "selfci", push to CI registry
-        sh "./scripts/re-tag-images.sh --src-tag $test_tag --alias-tag ${e2e_selfci_image_tag}"
+        sh "./scripts/re-tag-images.sh --src-tag $test_tag --alias-tag ${e2e_selfci_image_tag} --product mayastor"
       }
       post {
         always {

--- a/pipelines/common2/common.groovy
+++ b/pipelines/common2/common.groovy
@@ -142,6 +142,7 @@ def BuildImages2(Map params) {
   def test_tag = unwrap(params,'test_tag')
   def dataplane_dir = unwrap(params,'dataplane_dir')
   def controlplane_dir = unwrap(params,'controlplane_dir')
+  def product = unwrap(params,'product')
   def build_flags = ""
   if (params.containsKey('build_flags')) {
         build_flags = params['build_flags']
@@ -171,7 +172,7 @@ def BuildImages2(Map params) {
   // NOTE: create-install-image.sh should be part of the Jenkins repo
   // not mayastor-e2e
   // Build the install image
-  sh "./scripts/create-install-image.sh $build_flags --alias-tag \"$test_tag\" --mayastor ${dataplane_dir} --mcp ${controlplane_dir} --registry \"${env.REGISTRY}\""
+  sh "./scripts/create-install-image.sh $build_flags --alias-tag \"$test_tag\" --mayastor ${dataplane_dir} --mcp ${controlplane_dir} --registry \"${env.REGISTRY}\" --product \"${product}\" "
 
   // Limit any side-effects
   sh "rm -Rf ${dataplane_dir}/"
@@ -373,6 +374,7 @@ def RunOneTestPerCluster(e2e_test, loki_run_id, params) {
     def e2e_dir = unwrap(params,'e2e_dir')
     def kubernetes_version = unwrap(params,'kubernetes_version')
     def test_platform = unwrap(params,'test_platform')
+    def product = unwrap(params,'product')
 
     def failed_tests=""
     def k8s_job=""
@@ -422,7 +424,7 @@ def RunOneTestPerCluster(e2e_test, loki_run_id, params) {
         nix-shell --run './scripts/get_cluster_env.py --platform "${test_platform}" --oxray  "${envs_txt_file}" --oyaml "${envs_yaml_file}"'
     """
 
-    def cmd = "cd ${e2e_dir} && ./scripts/e2e-test.sh --device /dev/sdb --tag \"${e2e_image_tag}\"  --onfail stop --tests \"${testset}\" --loki_run_id \"${loki_run_id}\" --loki_test_label \"${e2e_test}\" --reportsdir \"${env.WORKSPACE}/${e2e_reports_dir}\" --registry \"${env.REGISTRY}\" --session \"${session_id}\" --ssh_identity \"${env.WORKSPACE}/${e2e_environment}/id_rsa\" "
+    def cmd = "cd ${e2e_dir} && ./scripts/e2e-test.sh --device /dev/sdb --tag \"${e2e_image_tag}\"  --onfail stop --tests \"${testset}\" --loki_run_id \"${loki_run_id}\" --loki_test_label \"${e2e_test}\" --reportsdir \"${env.WORKSPACE}/${e2e_reports_dir}\" --registry \"${env.REGISTRY}\" --session \"${session_id}\" --ssh_identity \"${env.WORKSPACE}/${e2e_environment}/id_rsa\" --product \"${product}\" "
     withCredentials([
       usernamePassword(credentialsId: 'GRAFANA_API', usernameVariable: 'grafana_api_user', passwordVariable: 'grafana_api_pw'),
       string(credentialsId: 'HCLOUD_TOKEN', variable: 'HCLOUD_TOKEN')

--- a/pipelines/generic-system-test/Jenkinsfile
+++ b/pipelines/generic-system-test/Jenkinsfile
@@ -55,7 +55,8 @@ def e2e_params = [
 
     datacore_bolt: false,
 
-    build_flags: ''
+    build_flags: '',
+    product: ''
 ]
 
 def max_parallel_stages = 0
@@ -122,8 +123,13 @@ pipeline {
                 error('Unhandled: both test_profile and list_of_tests are set')
             }
 
-            if (params.datacore_bolt == true && params.push2dockerhub == true) {
-                error('Bolt images cannot be pushed to dockerhub')
+            if (params.datacore_bolt == true) {
+                e2e_params['product'] = 'bolt'
+                if (params.push2dockerhub == true) {
+                    error('Bolt images cannot be pushed to dockerhub')
+                }
+            } else {
+                e2e_params['product'] = 'mayastor'
             }
 
             for (element in common.GetE2ESettings()) {
@@ -234,16 +240,17 @@ pipeline {
       }
       steps {
           println("push images to docker with tag ${dockerhub_tag}")
-        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+          catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
             script{
                 def src_tag = e2e_params['e2e_image_tag']
                 def dockerhub_tag = e2e_params['dockerhub_tag']
+                def product = e2e_params['product']
                 withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                     sh 'echo $PASSWORD | docker login -u $USERNAME --password-stdin'
                 }
-                sh "./scripts/re-tag-images.sh --src-tag ${src_tag} --alias-tag ${dockerhub_tag} --registry dockerhub"
+                sh "./scripts/re-tag-images.sh --src-tag ${src_tag} --alias-tag ${dockerhub_tag} --registry dockerhub --product ${product}"
             }
-        }
+         }
       }
       post {
           always {

--- a/scripts/create-install-image.sh
+++ b/scripts/create-install-image.sh
@@ -44,8 +44,9 @@ Options:
   --mcp                      Path to root Mayastor control plane directory
   --coverage                 Build is a coverage build
   --debug                    Build is debug build
+  --product                  Product key [mayastor, bolt]
 Examples:
-  $(basename "$0") --registry 127.0.0.1:5000 --alias-tag customized-tag
+  $(basename "$0") --registry 127.0.0.1:5000 --alias-tag customized-tag --product bolt
 EOF
 }
 
@@ -85,6 +86,22 @@ while [ "$#" -gt 0 ]; do
       shift
       build_info+=('"debug": true')
       ;;
+    --product)
+      shift
+      case $1 in
+          mayastor)
+             registry_subdir='mayadata'
+             ;;
+          bolt)
+             registry_subdir='datacore'
+             ;;
+          *)
+              echo "Unknown product: $1"
+              exit 1
+              ;;
+      esac
+      shift
+      ;;
     *)
       echo "Unknown option: $1"
       exit 1
@@ -102,7 +119,7 @@ if [ -z "$MCP_DIR" ]; then
     exit 127
 fi
 
-image="mayadata/install-images:${OUTPUT_TAG}"
+image="$registry_subdir/install-images:${OUTPUT_TAG}"
 reg_image="${REGISTRY}/${image}"
 
 DockerfileTxt="FROM scratch

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -48,6 +48,7 @@ profile_test_list=""
 ssh_identity=""
 grpc_code_gen=
 crd_code_gen=
+product=
 
 declare -A profiles
 # List and Sequence of tests.
@@ -95,8 +96,9 @@ Options:
   --crd_code_gen <true|false>
                             On true, custom resource clinet code will be generated
                             On false, custom resource clinet code will not be generated
+  --product                  Product key [mayastor, bolt]
 Examples:
-  $0 --device /dev/nvme0n1 --registry 127.0.0.1:5000 --tag a80ce0c
+  $0 --device /dev/nvme0n1 --registry 127.0.0.1:5000 --tag a80ce0c --product bolt
 EOF
 }
 
@@ -258,6 +260,21 @@ while [ "$#" -gt 0 ]; do
                     ;;
             esac
         ;;
+    --product)
+      shift
+      case $1 in
+          mayastor)
+             product="$1"
+             ;;
+          bolt)
+             product="$1"
+             ;;
+          *)
+              echo "Unknown product: $1"
+              exit 1
+              ;;
+      esac
+      ;;
     *)
       echo "Unknown option: $1"
       help
@@ -269,6 +286,11 @@ done
 
 export loki_run_id="$loki_run_id" # can be empty string
 export loki_test_label="$loki_test_label"
+
+if [ -z "$product" ]; then
+    echo "defaulting product to mayastor"
+    product="mayastor"
+fi
 
 if [ -z "$session" ]; then
     sessiondir="$ARTIFACTSDIR"
@@ -283,7 +305,7 @@ if [ -z "$mayastor_root_dir" ]; then
     mkdir -p "$sessiondir"
     export mayastor_root_dir="$ARTIFACTSDIR/install-bundle/$tag"
     mkdir -p "$mayastor_root_dir"
-    if ! "$SCRIPTDIR/extract-install-image.sh" --alias-tag "$tag" --installroot "$mayastor_root_dir"
+    if ! "$SCRIPTDIR/extract-install-image.sh" --alias-tag "$tag" --installroot "$mayastor_root_dir" --product "$product"
     then
         echo "Unable to extract install files for $tag"
         exit $EXITV_INVALID_OPTION

--- a/scripts/extract-install-image.sh
+++ b/scripts/extract-install-image.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 
 REGISTRY="ci-registry.mayastor-ci.mayadata.io"
 TAG=""
-SCRIPTDIR=$(dirname "$(realpath "$0")")
-E2EROOT=$(realpath "$SCRIPTDIR/..")
+#SCRIPTDIR=$(dirname "$(realpath "$0")")
+#E2EROOT=$(realpath "$SCRIPTDIR/..")
 INSTALLROOT=""
 
 
@@ -16,7 +16,7 @@ help() {
 This script extracts the templates and files required for E2E to install mayastor
 from a mayastor install image.
 
-Usage: $(basename $0) [OPTIONS]
+Usage: $(basename "$0") [OPTIONS]
 
 Options:
   -h, --help                 Display this text.
@@ -24,9 +24,10 @@ Options:
                              default is ${REGISTRY}
   --alias-tag                Tag of install image to use, default is ${TAG}
   --installroot              install root directory
+  --product                  Product key [mayastor, bolt]
 
 Examples:
-  $(basename $0) --registry 127.0.0.1:5000 --alias-tag customized-tag --installroot <path>
+  $(basename "$0") --registry 127.0.0.1:5000 --alias-tag customized-tag --installroot <path> --product bolt
 EOF
 }
 
@@ -55,6 +56,22 @@ while [ "$#" -gt 0 ]; do
       fi
       shift
       ;;
+    --product)
+      shift
+      case $1 in
+          mayastor)
+             registry_subdir='mayadata'
+             ;;
+          bolt)
+             registry_subdir='datacore'
+             ;;
+          *)
+              echo "Unknown product: $1"
+              exit 1
+              ;;
+      esac
+      shift
+      ;;
     *)
       echo "Unknown option: $1"
       exit 1
@@ -72,7 +89,7 @@ if [ -z "$INSTALLROOT" ] ; then
     help
 fi
 
-image=${REGISTRY}/mayadata/install-images:${TAG}
+image=${REGISTRY}/$registry_subdir/install-images:${TAG}
 docker pull "${image}"
 
 # if the install bundle directory exists, we should

--- a/scripts/re-tag-images.sh
+++ b/scripts/re-tag-images.sh
@@ -2,8 +2,7 @@
 
 set -euo pipefail
 
-RESTFUL_IMAGES="mayastor mayastor-csi mayastor-client install-images mcp-core mcp-rest mcp-csi-controller mcp-msp-operator"
-
+SCRIPTDIR=$(dirname "$(realpath "$0")")
 REGISTRY="ci-registry.mayastor-ci.mayadata.io"
 DESTINATION_REGISTRY="$REGISTRY"
 SRC_TAG=""
@@ -11,7 +10,7 @@ ALIAS_TAG=""
 
 help() {
   cat <<EOF
-Usage: $(basename $0) [OPTIONS]
+Usage: $(basename "$0") [OPTIONS]
 
 Options:
   -h, --help                 Display this text.
@@ -21,7 +20,7 @@ Options:
   --alias-tag                Tag to give CI image
 
 Examples:
-  $(basename $0) --registry 127.0.0.1:5000 --src-tag 755c435fdb0a --alias-tag customized-tag
+  $(basename "$0") --registry 127.0.0.1:5000 --src-tag 755c435fdb0a --alias-tag customized-tag
 EOF
 }
 
@@ -48,6 +47,23 @@ while [ "$#" -gt 0 ]; do
       ALIAS_TAG=$1
       shift
       ;;
+    --product)
+      shift
+      case $1 in
+          mayastor)
+              registry_subdir='mayadata'
+              ;;
+          bolt)
+              registry_subdir='datacore'
+              ;;
+          *)
+              echo "Unknown product: $1"
+              exit 1
+              ;;
+      esac
+      product="$1"
+      shift
+      ;;
     *)
       echo "Unknown option: $1"
       exit 1
@@ -67,22 +83,41 @@ if [ -z "$ALIAS_TAG" ] ; then
     exit 1
 fi
 
-
-images=$RESTFUL_IMAGES
+# extract the install bundle - and collect the names of mayadata/datacore images
+# from helm chart yaml files.
+# convert lines like
+#   {{ .Values.mayastorCP.registry }}datacore/bolt-rest:{{ .Values.mayastorCP.tag }}
+# to
+#   bolt-rest
+tmpdir=$(mktemp -d)
+"$SCRIPTDIR/extract-install-image.sh" --alias-tag "$SRC_TAG" --installroot "$tmpdir" --product "$product"
+images=$(find "$tmpdir" -type f -name '*.yaml' -print0 \
+    | xargs -0 grep -w image \
+    | grep -w -e datacore -e mayadata \
+    | sed  \
+    -e 's#.*datacore/##' \
+    -e 's#.*mayadata/##' \
+    -e 's#:{{.*##' \
+)
+rm -rf "$tmpdir"
+# When we re-tag images for the internal registry we should re-tag
+# the install bundle as well, so add that image to the list
+images="$images
+install-images"
 
 for name in $images; do
-  input_image="${REGISTRY}/mayadata/${name}:${SRC_TAG}"
+  input_image="${REGISTRY}/$registry_subdir/${name}:${SRC_TAG}"
 
   docker pull "${input_image}"
 
   if [ "$DESTINATION_REGISTRY" == "dockerhub" ]; then
-    output_image="mayadata/${name}:${ALIAS_TAG}"
+    output_image="$registry_subdir/${name}:${ALIAS_TAG}"
     # do not upload install-images to dockerhub
     if [ "$name" == "install-images" ]; then
         continue
     fi
   else
-    output_image="${DESTINATION_REGISTRY}/mayadata/${name}:${ALIAS_TAG}"
+    output_image="${DESTINATION_REGISTRY}/$registry_subdir/${name}:${ALIAS_TAG}"
   fi
 
   docker tag "${input_image}" "${output_image}"


### PR DESCRIPTION
Create install-images for bolt in the registry under datacore/
Fix the fallout from that change.

Make re-tag-images more portable.
As a bonus this should just work correctly with older images
which have different image names